### PR TITLE
As of October 10, 2011 the t.co URL wrapper automatically wraps all links submitted to Twitter, regardless of length.

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -574,7 +574,7 @@ function updateCount() {
 	// for calculate length with shorten URL.
 	var s = $("fst").value.replace(
 			/https?:\/\/[^\/\s]*[\w!#$%&'()*+,.\/:;=?@~-]+(?=&\w+;)|https?:\/\/[^\/\s]*[\w!#$%&'()*+,.\/:;=?@~-]+/g,
-			function(t) {return t_co_maxstr.slice(0, t.length) + (t.substr(t.length-1) == ')' ? ')' : '');});
+			function(t) {return t_co_maxstr + (t.substr(t.length-1) == ')' ? ')' : '');});
 	$("counter").innerHTML = 140 - footer.length - s.length;
 }
 // フォームの初期化


### PR DESCRIPTION
As of October 10, 2011 the t.co URL wrapper automatically wraps all links submitted to Twitter, regardless of length.
https://dev.twitter.com/docs/tco-url-wrapper
