### PR TITLE
Adjust shorten URL length with https.

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -577,7 +577,7 @@ function updateCount() {
 	// for calculate length with shorten URL.
 	var s = $("fst").value.replace(
 			/https?:\/\/[^\/\s]*[\w!#$%&'()*+,.\/:;=?@~-]+(?=&\w+;)|https?:\/\/[^\/\s]*[\w!#$%&'()*+,.\/:;=?@~-]+/g,
-			function(t) {return t_co_maxstr + (t.substr(t.length-1) == ')' ? ')' : '');});
+			function(t) {return t_co_maxstr.replace(/^http/, t.substr(0, t.indexOf(':'))) + (t.substr(t.length-1) == ')' ? ')' : '')});
 	$("counter").innerHTML = 140 - footer.length - s.length;
 }
 // フォームの初期化


### PR DESCRIPTION
ツイートに含まれる URL が https のとき、残り文字数を正しく計算するようにしました。
