### PR TITLE
Don't include last ':' from URL

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -842,7 +842,7 @@ function makeHTML(tw, no_name, pid, userdesc) {
 		text.replace(/https?:\/\/[^\/\s]*[\w!#$%&'()*+,.\/:;=?@~-]+(?=&\w+;)|https?:\/\/[^\/\s]*[\w!#$%&'()*+,.\/:;=?@~-]+|[@＠](\w+(?:\/[\w-]+)?)|([,.!?　、。！？「」]|\s|^)([#＃])([\w々ぁ-ゖァ-ヺーㄱ-ㆅ㐀-\u4DBF一-\u9FFF가-\uD7FF\uF900-\uFAFF０-９Ａ-Ｚａ-ｚｦ-ﾟ]+)(?=[^\w々ぁ-ゖァ-ヺーㄱ-ㆅ㐀-\u4DBF一-\u9FFF가-\uD7FF\uF900-\uFAFF０-９Ａ-Ｚａ-ｚｦ-ﾟ]|$)/g, function(_,u,x,h,s){
 				if (!u && !h) {
 					var paren = '';
-					_ = _.replace(/[()]+$/,function(p){ // 末尾の"()"はURLに含めない
+					_ = _.replace(/[():]+$/,function(p){ // 末尾の"():"はURLに含めない
 						paren = p;
 						return '';
 					});


### PR DESCRIPTION
Twitter の web に合わせて URL の後の : を URL と見なさないようにしました。

例 (asahi.com: ...)
- http://twitter.com/_wa_/statuses/169448381985464320
