### PR TITLE
Fix unnecessary loop in applyLinearGrad()

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -1009,7 +1009,7 @@ function applyLinearGrad(ele, dir, c, amax) {
 	var r = parseInt(c.substr(0,2), 16);
 	var g = parseInt(c.substr(2,2), 16);
 	var b = parseInt(c.substr(4,2), 16);
-	for (var i = 0; i < 5; i++) {
+	for (var i = 0; i < 4; i++) {
 		var prefix = ['-moz-','-webkit-','-o-',''][i];
 		try {
 			ele.style.background = prefix + 'linear-gradient(' +


### PR DESCRIPTION
applyLinearGrad で、ループが1回多くて CSS のエラーが出ていたのを直しました。
IE7/8 対応の修正漏れ?
