### PR TITLE
CSSを書きやすくなるように出力するHTMLを変更

### DIFF
--- a/plugins/debug.js
+++ b/plugins/debug.js
@@ -22,7 +22,7 @@ registerPlugin({
 			__map($("tw").childNodes, function(x){return __map(x.childNodes,function(y){return [y.tw?y.tw.id:-1,y.weak]})}) + "\n" + 
 			__map($("re").childNodes, function(x){return __map(x.childNodes,function(y){return [y.tw?y.tw.id:-1,y.weak]})}) + "\n" + 
 			'</textarea>' +
-			'<input type="submit" value="Submit debug log"></form>';
+			'<button type="submit">Submit debug log</button></form>';
 		$("pref").appendChild(e);
 	}
 });

--- a/plugins/followers.js
+++ b/plugins/followers.js
@@ -13,7 +13,7 @@ for (var i = 0; i < followers_ids_list.length; i++)
 registerPlugin({
 	miscTab: function(ele) {
 		var e = document.createElement("div");
-		e.innerHTML = '<form onSubmit="twfcFollwersIDsRenew(); return false;">'+_('Color followers')+': <span id="followers_status">'+(followers_ids_list.length?"on("+followers_ids_list.length+")":"off")+'</span> <input type="submit" value="'+_('Renew')+'"><input type="button" onClick="twfcFollwersIDsClear()" value="'+_('Off')+'"> <a href="javascript:alert(\''+_('Tweets coloring')+':\\n  '+_('follower: black  non-follower: blue')+'\')">[?]</a></form>';
+		e.innerHTML = '<form onSubmit="twfcFollwersIDsRenew(); return false;">'+_('Color followers')+': <span id="followers_status">'+(followers_ids_list.length?"on("+followers_ids_list.length+")":"off")+'</span> <button type="submit">'+_('Renew')+'</button><button type="button" onClick="twfcFollwersIDsClear()">'+_('Off')+'</button> <a href="javascript:alert(\''+_('Tweets coloring')+':\\n  '+_('follower: black  non-follower: blue')+'\')">[?]</a></form>';
 		ele.appendChild(e);
 		var hr = document.createElement("hr");
 		hr.className = "spacer";

--- a/plugins/lists.js
+++ b/plugins/lists.js
@@ -184,13 +184,10 @@ function twlUpdateMisc() {
 		var users = lists_users[a];
 		return a != "" ? '<li><a target="twitter" href="' + twitterURL + a + '">@'+ a + '</a>' +
 			' (' + (users ? users.length : "error") + ') ' +
-			'<input onchange="twlToggleListsInTL(\''+a+'\',this)" type="checkbox" '+
-					'id="chk-lists-'+a.replace('/','-')+'"'+chk+'>'+
-			'<label for="chk-lists-'+a.replace('/','-')+'">TL</label>&nbsp;&nbsp;'+
+			'<label><input type="checkbox" onchange="twlToggleListsInTL(\''+a+'\',this)" id="chk-lists-'+a.replace('/','-')+'" '+chk+'>TL</label>&nbsp;&nbsp;'+
 			' <a class="close" href="javascript:twlUnsubscribeList(\''+a+'\')">'+
 			'<img style="position: relative; top: 2px;" src="images/clr.png"></a>'+
-			'<input type="button" onclick="twlReloadListInfo(\'' + a + '\')" '+
-					'value="'+ _('Reload') + '"></a>'+
+			'<button type="button" onclick="twlReloadListInfo(\'' + a + '\')">'+ _('Reload') + '</button></a>'+
 			'</li>' : a
 	}).join("");
 }
@@ -254,10 +251,9 @@ registerPlugin({
 			'<form id="lists_pref" style="display:none" onSubmit="twlSubscribeList($(\'newList\').value); return false;">' +
 			_('subscribing lists by twicli')+':<ul id="lists_list">' +
 			'</ul><ul><li><input type="text" size="15" id="newList" value="">' +
-			'<input type="submit" value="'+_('Add')+'"></li></ul><p>' +
-			'<input id="auto_update" type="checkbox" onchange="twlSetAutoUpdate(this.checked)"' +
-			(list_auto_update ? ' checked' : '') + '>' +
-			'<label for="auto_update">' + _('Update tweets in list tab automatically') +
+			'<button type="submit">'+_('Add')+'</button></li></ul><p>' +
+			'<label><input type="checkbox" id="auto_update" onchange="twlSetAutoUpdate(this.checked)"' +
+			(list_auto_update ? ' checked' : '') + '>'+ _('Update tweets in list tab automatically') +
 			'</label></form>';
 		$("pref").appendChild(e);
 		twlUpdateMisc();

--- a/plugins/multi_account.js
+++ b/plugins/multi_account.js
@@ -50,9 +50,9 @@ registerPlugin({
 	miscTab: function(ele) {
 		var e = document.createElement('div');
 		e.innerHTML = _('Accounts')+': <select id="accounts"></select>' +
-				' <input type="image" onclick="accounts_change(); return false" alt="switch" title="switch" src="images/go.png">' +
-				'<input type="image" onclick="accounts_delete(); return false" alt="delete" title="delete" src="images/clr.png">' +
-				' <input type="image" onclick="accounts_add(); return false" alt="add" title="add" src="images/add.png"><br>';
+				'<button type="button" class="go" onclick="accounts_change(); return false"></button>' +
+				'<button type="button" class="clr" onclick="accounts_delete(); return false"></button>' +
+				'<button type="button" class="add" onclick="accounts_add(); return false"></button><br>';
 		$('tw2h').insertBefore(e, $('logout'));
 		
 		for (var x in accounts_info) {

--- a/plugins/outputz.js
+++ b/plugins/outputz.js
@@ -11,7 +11,7 @@ function setOutputzKey(key) {
 registerPlugin({
 	miscTab: function(ele) {
 		var e = document.createElement("div");
-		e.innerHTML = '<form onSubmit="setOutputzKey($(\'outputz_key\').value); return false;"><a target="outputz" href="http://outputz.com/">Outputz</a> key : <input type="text" size="15" id="outputz_key" value="'+(outputz_key?'(enabled)':'')+'"><input type="image" src="images/go.png"></form>';
+		e.innerHTML = '<form onSubmit="setOutputzKey($(\'outputz_key\').value); return false;"><a target="outputz" href="http://outputz.com/">Outputz</a> key : <input type="text" size="15" id="outputz_key" value="'+(outputz_key?'(enabled)':'')+'"><button type="submit" class="go"></form>';
 		ele.appendChild(e);
 		var hr = document.createElement("hr");
 		hr.className = "spacer";

--- a/plugins/regexp.js
+++ b/plugins/regexp.js
@@ -159,7 +159,7 @@ initRegexp();
 registerPlugin({
 	miscTab: function(ele) {
 		var e = document.createElement("div");
-		e.innerHTML = _('Pickup Pattern')+' <small>'+_('(TabName:ID:Tweet:Filter)')+'</small> : <br><form onSubmit="setRegexp($(\'pickup_regexp\').value); return false;"><textarea cols="30" rows="4" id="pickup_regexp">' + pickup_regexp + '</textarea><br><input type="submit" value="'+_('Apply')+'"></form>';
+		e.innerHTML = _('Pickup Pattern')+' <small>'+_('(TabName:ID:Tweet:Filter)')+'</small> : <br><form onSubmit="setRegexp($(\'pickup_regexp\').value); return false;"><textarea cols="30" rows="4" id="pickup_regexp">' + pickup_regexp + '</textarea><br><button type="submit">'+_('Apply')+'</button></form>';
 		ele.appendChild(e);
 		var hr = document.createElement("hr");
 		hr.className = "spacer";

--- a/plugins/search.js
+++ b/plugins/search.js
@@ -42,7 +42,7 @@ function twsSearch(qn, no_switch, max_id) {
 	if (tws_update_timer) clearInterval(tws_update_timer);
 	tws_update_timer = setInterval(function(){twsSearchUpdate(q,lang)}, 1000*Math.max(parseInt(readCookie('update_interval')) || 90, 30));
 	var rt_checked = exclude_rt ? "" : " checked";
-	$('tw2h').innerHTML = '<div class="tabcmd tabclose"><input id="tws-RT" type="checkbox"'+rt_checked+'><label for="tws-RT">RT</label> <a id="tws-closetab" href="#">[x] '+_('remove tab')+'</a></div>';
+	$('tw2h').innerHTML = '<div class="tabcmd tabclose"><label><input type="checkbox" id="tws-RT"'+rt_checked+'>RT</label> <a id="tws-closetab" href="#">[x] '+_('remove tab')+'</a></div>';
 	$('tws-closetab').onclick = function(){ closeSearchTab(myid); return false; };
 	if (!max_id) tws_page = 0;
 	$('tws-RT').onclick = function() { twsSwitchRT(myid); };
@@ -111,7 +111,7 @@ registerPlugin({
 	},
 	miscTab: function(ele) {
 		var e = document.createElement("div");
-		e.innerHTML = '<form onSubmit="return twsSearch($(\'search_q\').value);"><a href="https://twitter.com/search" target="_blank">'+_('Twitter search')+'</a> : <input type="text" size="15" id="search_q"><input type="image" src="images/go.png"></form>';
+		e.innerHTML = '<form onSubmit="return twsSearch($(\'search_q\').value);"><a href="https://twitter.com/search" target="_blank">'+_('Twitter search')+'</a> : <input type="text" size="15" id="search_q"><button type="submit" class="go"></button></form>';
 		ele.appendChild(e);
 		var hr = document.createElement("hr");
 		hr.className = "spacer";

--- a/plugins/search2.js
+++ b/plugins/search2.js
@@ -33,7 +33,7 @@ function twsjSearchShow(res) {
 registerPlugin({
 	miscTab: function(ele) {
 		var e = document.createElement("div");
-		e.innerHTML = '<form onSubmit="twsjSearch($(\'searchj_q\').value); return false;"><a target="twitter" href="http://yats-data.com/yats/">'+_('Twitter search (yats)')+'</a>: <input type="text" size="15" id="searchj_q"><input type="image" src="images/go.png"></form>';
+		e.innerHTML = '<form onSubmit="twsjSearch($(\'searchj_q\').value); return false;"><a target="twitter" href="http://yats-data.com/yats/">'+_('Twitter search (yats)')+'</a>: <input type="text" size="15" id="searchj_q"><button type="submit" class="go"></form>';
 		ele.appendChild(e);
 		var hr = document.createElement("hr");
 		hr.className = "spacer";

--- a/plugins/shortcutkey.js
+++ b/plugins/shortcutkey.js
@@ -267,14 +267,8 @@ var shortcutkey_plugin = {
 			case 191: // / : インクリメンタルサーチ
 				shortcutkey_plugin.resetInclementalSearch();
 				var filter_div = document.createElement('div');
-				filter_div.style.position = 'fixed';
-				filter_div.style.left = 0;
-				filter_div.style.top = 0;
-				filter_div.style.width = '100%';
-				filter_div.style.height = '3em';
-				filter_div.style.zIndex = 100;
-				filter_div.style.className = 'filter-form';
-				filter_div.innerHTML = '<div style="margin: 4px; padding: 10px; width: 95%; height: 2em; border: solid 1px grey; background-color: #ffe; box-shadow: 0 3px 5px grey; font-size: small; text-align: center;"><a style="color: red" href="javascript:void(shortcutkey_plugin.resetInclementalSearch())">[x]</a> Filter: <input id="filter-field" style="width: 75%"></div>';
+				filter_div.id = 'filter-form';
+				filter_div.innerHTML = '<a href="javascript:void(shortcutkey_plugin.resetInclementalSearch())">[x]</a> Filter: <input type="text" id="filter-field">';
 				document.body.appendChild(filter_div);
 				shortcutkey_plugin.filter_div = filter_div;
 				$('filter-field').onkeydown = $('filter-field').onkeypress = shortcutkey_plugin.startInclementalSearch;

--- a/plugins/sound.js
+++ b/plugins/sound.js
@@ -23,7 +23,7 @@ registerPlugin({
 			'<form id="sound_pref" style="display:none" onSubmit="setSoundNames([$(\'sound0\').value,$(\'sound1\').value]); return false;">' +
 			_('on TL update')+': <input type="text" size="15" id="sound0" value="'+sound_name[0]+'"><br>' +
 			_('on new Reply')+': <input type="text" size="15" id="sound1" value="'+sound_name[1]+'"><br>' +
-			'<input type="submit" value="Apply"></form>';
+			'<button type="submit">Apply</button></form>';
 		$("pref").appendChild(e);
 	},
 	noticeUpdate: function(tw, nr) {

--- a/plugins/translate.js
+++ b/plugins/translate.js
@@ -16,7 +16,7 @@ registerPlugin({
 		e.innerHTML = '<a href="javascript:var s = $(\'translate_pref\').style; s.display = s.display==\'block\'?\'none\':\'block\';void(0)"><b>▼'+_('Translate')+'</b></a>' +
 			'<form id="translate_pref" style="display:none" onSubmit="setTranslateLang($(\'translateLang\').value); return false;">' +
 			_('translate language')+': <input type="text" size="15" id="translateLang" value="'+translateLang+'">' +
-			'<input type="image" src="images/go.png"></form>';
+			'<button type="submit" class="go"></form>';
 		$("pref").appendChild(e);
 	},
 

--- a/styles/default.css
+++ b/styles/default.css
@@ -4,6 +4,8 @@ hr { margin: 0; padding: 0; }
 hr.spacer { margin: 6px 0 }
 iframe { display: none; }
 form { margin-bottom: 0; }
+label, button, input[type="submit"], input[type="button"], input[type="image"], input[type="checkbox"], input[type="radio"], input[type="file"], select { cursor: pointer; }
+.go:before, .clr:before, .add:before, .lock:before, .verified:before { content: '.'; color: transparent; } /* 行中のアイコンの位置を揃える */
 
 #control { position: fixed; top: 0; left: 0; width: 100%; height: 53px; border-bottom: 1px solid black; z-index: 3; background-color: #eee; }
 #loading { opacity: 0.5; filter: alpha(opacity=50); display: inline; position: absolute; top: 6px; left: 50%; z-index: 4; margin-left: -120px; }
@@ -13,7 +15,11 @@ form { margin-bottom: 0; }
 #option { position: absolute; left: 1px; top: 32px; width: 99%; font-size: smaller; }
 #option > div, #option > form { display: inline-block; }
 #media_div { min-width: 256px; min-height: 1em; display: inline-block; }
-#imgclr { position: relative; z-index: 21; cursor: pointer; }
+.go, .clr, .add { background-color: transparent;  background-repeat: no-repeat; width: 14px; height: 14px; padding: 0px; border: 0px none; position: relative; cursor: pointer; display: inline-block; }
+.go { background-image: url("../images/go.png"); }
+.clr { background-image: url('../images/clr.png');}
+.add { background-image: url('../images/add.png'); }
+#imgclr { z-index: 21; }
 #menu { position: absolute; left: 0px; top: 33px; }
 #menu a { display: inline-block; font-size: 12px; height: 18px; line-height: 18px; border: 1px solid black; border-bottom: 0 none; background-color: #aaa; color: #242; padding: 0 4px; margin: 0; margin-bottom: 2px; text-decoration: none; font-family: sans-serif; -moz-border-radius: 5px 5px 0 0; -webkit-border-top-left-radius: 5px; -webkit-border-top-right-radius: 5px; border-radius: 5px 5px 0 0; margin-right: 2px; overflow: hidden; max-width: 10em; white-space: nowrap; text-overflow: ellipsis; }
 #menu a.sel { height: 20px; margin-bottom: 0; background-color: #ffe; color: #002; border-bottom-color: #fff; }
@@ -34,7 +40,7 @@ form { margin-bottom: 0; }
 .uicon { float: left; width: 32px; height: 32px; padding-right: 1px; }
 .uicon2 { max-width: 96px; max-height: 96px; }
 .rtuicon { width: 16px; height: 16px; padding: 0 1px; vertical-align: bottom; }
-.fav { float: right; }
+.fav { float: right; cursor: pointer; }
 .dir { color: #679; }
 .status { text-decoration: none; }
 .status a.link { font-size: smaller; background-color: #eee; color: #022; border: solid 1px #cec; text-decoration: none; }
@@ -59,10 +65,13 @@ form { margin-bottom: 0; }
 .inrep .reply img { border: solid green 1px; border-radius: 5px; background-color: yellow; position: relative; top: 3px; padding: 0 0 2px 0; }
 .popup { padding: 0 4px; color: #888; }
 .upopup { float: right; padding: 0 16px; color: #888; }
-.verified { vertical-align: -2px; }
-.lock { vertical-align: -2px; }
+.verified { background-image: url("../images/verified.png"); display: inline-block; width: 15px; height: 15px; vertical-align: -2px; }
+.lock { background-image: url("../images/icon_lock.gif"); display: inline-block; width: 7px; height: 11px; vertical-align: -2px; }
 .close { display: inline-block; color: red; margin: 4px; }
 .get-next { text-align: center; background-color: #999; color: #fec; cursor: pointer; }
+.get-next:before { content: '▽';}
+.get-next span:before { content: '(';}
+.get-next span:after { content: ')';}
 #rep { display: none; background-color: #fee; position: absolute; width: 90%; left: 4%; top: 200px; border: 4px solid #666; z-index: 2; padding: 2px; font-size: smaller; overflow: hidden; }
 #rep > a > img { padding: 2px 1px 1px 3px; }
 #reps { margin-top: 1px; }
@@ -91,7 +100,7 @@ form { margin-bottom: 0; }
 }
 .uicona { display: inline-block; margin: 4px; padding: 4px; border-radius: 5px; background-color: white; }
 #profile { padding: 4px 16px; font-family: "Helvetica Neue",Arial,sans-serif; }
-.selected { background-color: #ffb !important; }
+.selected { background-color: #ffb; }
 .deleted > .status { text-decoration: line-through; }
 .nrFav { background-color: #3fc; font-size: smaller; }
 .skipped { background-color: #eee; font-size: smaller; text-align: center; }
@@ -111,6 +120,10 @@ form { margin-bottom: 0; }
 .thumbnail-image { border: solid 2px white; max-width: 32px; width: 32px\9; height: auto; -moz-transition: all 0.3s ease; -webkit-transition: all 0.3s ease; transition: all 0.2s ease; -o-transition: all 0.3s ease; }
 .thumbnail-image:hover { border: solid 2px white; width: auto; max-width: 200px; }
 .thumbnail-link { border: solid 1px grey; display: block; float: right; }
+
+#filter-form { position: fixed; left: 0; right: 0px; margin: 4px; padding: 10px; top: 0; z-index: 100; border: solid 1px grey; background-color: #ffe; box-shadow: 0 3px 5px grey; font-size: small; text-align: center; }
+#filter-form a { color: red;}
+#filter-form input { width: 75%; }
 
 @media screen and (max-device-width: 480px) {
 	#menu a { padding: 1px 5px; height: 22px; line-height: 22px; }

--- a/twicli.js
+++ b/twicli.js
@@ -1074,7 +1074,7 @@ function makeHTML(tw, no_name, pid, userdesc) {
 		//Retweet情報
 		'<span id="rtinfo-'+eid+'" class="rtinfo">' +
 		(tw.metadata && tw.metadata.result_type=="popular" ? "<img src=\"images/popular.png\" alt=\"pop\">" : "") +
-		(!display_as_rt && rt ? "<img src=\"images/rt.png\" alt=\"RT\">by <img src=\""+tw.user.profile_image_url+"\" alt=\""+tw.user.screen_name+"\" class=\"rtuicon\"><a href=\""+twitterURL+tw.user.screen_name+"\" onclick=\"switchUserTL(this.parentNode.parentNode, true);return false\">" + tw.user.screen_name + "</a><span class=\"cnt\">" + (parseInt(tw.retweet_count) > 1 ? '& ' + (typeof(tw.retweet_count) == 'string' ? tw.retweet_count : tw.retweet_count-1) : '') : parseInt(tw.retweet_count) > 1 ? '<img src="images/rt2.png" class="rtinfoicon" alt="RT">' + tw.retweet_count : '') + '</span></span>' +
+		(!display_as_rt && rt ? "<img src=\"images/rt.png\" alt=\"RT\">by <img src=\""+tw.user.profile_image_url+"\" alt=\""+tw.user.screen_name+"\" class=\"rtuicon\"><a href=\""+twitterURL+tw.user.screen_name+"\" onclick=\"switchUserTL(this.parentNode.parentNode, true);return false\">" + tw.user.screen_name + "</a><span class=\"cnt\">" + (parseInt(tw.retweet_count) > 1 ? '& ' + (typeof(tw.retweet_count) == 'string' ? tw.retweet_count : tw.retweet_count-1) : '') : parseInt(tw.retweet_count) > 1 ? '<img src="images/rt2.png" class="rtinfoicon" alt="RT"><span class=\"cnt\">' + tw.retweet_count+'</span>' : '') + '</span></span>' +
 		//Favorited情報
 		'<span id="favinfo-'+eid+'" class="favinfo">' +
 		(parseInt(tw.favorite_count) > 0 ? "<img src=\"images/fav.png\" alt=\"Fav\" class=\"favinfoicon\"><span class=\"cnt\">" + tw.favorite_count : '')+ '</span></span>' +

--- a/twicli.js
+++ b/twicli.js
@@ -1042,8 +1042,8 @@ function makeHTML(tw, no_name, pid, userdesc) {
 		Array.prototype.concat.apply(tw.entities.urls, tw.entities.media || []).map(function(_){
 			if (_.url && _.expanded_url) expanded_urls[_.url] = _.expanded_url;
 		});
-	return /*fav*/ (t.d_dir ? '' : '<img alt="☆" class="fav" src="images/icon_star_'+(!rt&&rs.favorited?'full':'empty')+'.gif" ' +
-			'onClick="fav(this,\'' + id + '\')"' + (pid ? ' id="fav-'+eid+'"' : '') + '>')+
+	return /*fav*/ (t.d_dir ? '' : '<div class="fav"><img alt="☆" src="images/icon_star_'+(!rt&&rs.favorited?'full':'empty')+'.gif" ' +
+			'onClick="fav(this,\'' + id + '\')"' + (pid ? ' id="fav-'+eid+'"' : '') + '><span></span></div>')+
 		 (!no_name || (!display_as_rt && rt) ?
 			//ユーザアイコン
 			'<img class="uicon" src="' + t.user.profile_image_url + '" title="' + (t.user.description ? t.user.description.replace(/\"/g,'&quot;') :'') + '" onClick="switchUserTL(this.parentNode,'+rt_mode+');return false">' + (t.user.url ? '</a>' : '') +
@@ -1051,8 +1051,8 @@ function makeHTML(tw, no_name, pid, userdesc) {
 			'<a href="' + twitterURL + un + '" onClick="switchUserTL(this.parentNode,'+rt_mode+');return false"><span class="uid">' + un + '</span>' +
 			 /*プロフィールの名前*/ (t.user.name!=un ? '<span class="uname">('+insertPDF(t.user.name)+')</span>' : '') + '</a>'
 		: '') +
-		 /* verified? */ (!no_name && t.user.verified ? '<img alt="verified" id="verified-' + eid + '" class="verified" src="images/verified.png">' : '') +
-		 /* protected? */ (t.user.protected ? '<img alt="lock" id="lock-' + eid + '" class="lock" src="images/icon_lock.gif">' : '') +
+		 /* verified? */ (!no_name && t.user.verified ? '<div id="verified-' + eid + '" class="verified"></div>' : '') +
+		 /* protected? */ (t.user.protected ? '<div alt="lock" id="lock-' + eid + '" class="lock"></div>' : '') +
 		/*ダイレクトメッセージの方向*/ (t.d_dir == 1 ? '<span class="dir">→</span> ' : t.d_dir == 2 ? '<span class="dir">←</span> ' : '') +
 		//本文 (https〜をリンクに置換 + @を本家リンク+JavaScriptに置換)
 		" <span id=\"text-" + eid + "\" class=\"status\">" +
@@ -1072,15 +1072,14 @@ function makeHTML(tw, no_name, pid, userdesc) {
 				return "<a href=\""+twitterURL+u+"\"  class=\"mention\" onClick=\"switchUser('"+u+"'); return false;\" >"+_+"</a>";
 			}).replace(/\r?\n|\r/g, "<br>") + '</span>' +
 		//Retweet情報
-		' <span id="rtinfo-'+eid+'" class="rtinfo">' +
+		'<span id="rtinfo-'+eid+'" class="rtinfo">' +
 		(tw.metadata && tw.metadata.result_type=="popular" ? "<img src=\"images/popular.png\" alt=\"pop\">" : "") +
-		(!display_as_rt && rt ? "<img src=\"images/rt.png\" alt=\"RT\">by <img src=\""+tw.user.profile_image_url+"\" alt=\""+tw.user.screen_name+"\" class=\"rtuicon\"><a href=\""+twitterURL+tw.user.screen_name+"\" onclick=\"switchUserTL(this.parentNode.parentNode, true);return false\">" + tw.user.screen_name + "</a> " + (parseInt(tw.retweet_count) > 1 ? '& ' + (typeof(tw.retweet_count) == 'string' ? tw.retweet_count : tw.retweet_count-1) : '') : parseInt(tw.retweet_count) > 1 ? '<small><img src="images/rt2.png" class="rtinfoicon" alt="RT">' + tw.retweet_count+'</small>' : '') + '</span>' +
+		(!display_as_rt && rt ? "<img src=\"images/rt.png\" alt=\"RT\">by <img src=\""+tw.user.profile_image_url+"\" alt=\""+tw.user.screen_name+"\" class=\"rtuicon\"><a href=\""+twitterURL+tw.user.screen_name+"\" onclick=\"switchUserTL(this.parentNode.parentNode, true);return false\">" + tw.user.screen_name + "</a><span class=\"cnt\">" + (parseInt(tw.retweet_count) > 1 ? '& ' + (typeof(tw.retweet_count) == 'string' ? tw.retweet_count : tw.retweet_count-1) : '') : parseInt(tw.retweet_count) > 1 ? '<img src="images/rt2.png" class="rtinfoicon" alt="RT">' + tw.retweet_count : '') + '</span></span>' +
 		//Favorited情報
-		' <span id="favinfo-'+eid+'" class="favinfo">' +
-		(parseInt(tw.favorite_count) > 0 ? "<img src=\"images/fav.png\" alt=\"Fav\" class=\"favinfoicon\">" + tw.favorite_count : '')
-		+ '</span>' +
+		'<span id="favinfo-'+eid+'" class="favinfo">' +
+		(parseInt(tw.favorite_count) > 0 ? "<img src=\"images/fav.png\" alt=\"Fav\" class=\"favinfoicon\"><span class=\"cnt\">" + tw.favorite_count : '')+ '</span></span>' +
 		//日付
-		' <span id="utils-'+eid+'" class="utils">' +
+		'<span id="utils-'+eid+'" class="utils">' +
 		'<span class="prop"><a class="date" target="twitter" href="'+twitterURL+(t.d_dir ? '#!/messages' : un+'/statuses/'+id2)+'">' + dateFmt(t.created_at) + '</a>' +
 		//クライアント
 		(t.source ? '<span class="separator"> / </span><span class="source">' + t.source.replace(/<a /,'<a target="twitter"') + '</span>' : '') + '</span>' +
@@ -1108,7 +1107,7 @@ function makeUserInfoHTML(user) {
 						'<a href="' + twitterURL + user.screen_name + '/followers" onclick="switchFollower();return false;">' + user.followers_count + '<small>'+_('followers')+'</small></a>' +
 			' / <a href="' + twitterURL + user.screen_name + '" onclick="switchStatus();return false;">' + user.statuses_count + '<small>'+_('tweets')+'</small></a> / ' +
 						'<a href="' + twitterURL + user.screen_name + '/favorites" onclick="switchFav();return false;">' + user.favourites_count + '<small>'+_('favs')+'</small></a></b>' +
-			'</div><div class="clr"></div>'+
+			'</div></div>'+
 			(user.screen_name != myname ? '<a class="button upopup" href="#" onClick="userinfo_popup_menu(\'' + user.screen_name + '\',' + user.id + ', this); return false;"><small><small>▼</small></small></a>' : '')+
 			'<a target="twitter" href="' + twitterURL + user.screen_name + '">[Twitter]</a>'
 }
@@ -1126,7 +1125,7 @@ function nextButton(id, p) {
 	ret.id = id;
 	ret.className = 'get-next';
 	ret.onclick = function() { getNext(this); };
-	ret.innerHTML = '▽' + (p ? '(' + p + ')' : '');
+	ret.innerHTML = (p ? '<span>' + p + '</span>' : '');
 	return ret;
 }
 // favoriteの追加/削除
@@ -1220,8 +1219,7 @@ function twRelation(rel) {
 	var elem = $("user_info");
 	if (source.followed_by)
 		elem.innerHTML += '<a href="javascript:replyTo(\'' + rel.relationship.target.screen_name + '\',0,0,1)">[DM]</a>';
-	elem.innerHTML += '<input type="button" value="' + _(source.following ? 'Remove $1' : 'Follow $1', last_user) +
-					'" onClick="follow('+!source.following+')">';
+	elem.innerHTML += '<button type="button" onClick="follow('+!source.following+')">' + _(source.following ? 'Remove $1' : 'Follow $1', last_user) + '</button>';
 	if (source.followed_by)
 		$("profile").innerHTML += "<br><span id=\"following_you\" class=\"following_you\">" + _('$1 is following you!', rel.relationship.target.screen_name)+'</span>';
 	callPlugins("newUserRelationship", elem, rel);
@@ -1747,33 +1745,33 @@ function switchMisc() {
 	$("tw2h").innerHTML = '<br><a id="clientname" target="twitter" href="index.html"><b>twicli</b></a> : A browser-based Twitter client<br><small id="copyright">Copyright &copy; 2008-2015 NeoCat</small><hr class="spacer">' +
 	'<a href="javascript:showMediaOption()">' + _('Upload images') + '</a><br>' +
 					'<form id="switchuser" onSubmit="switchUser($(\'user_id\').value); return false;">'+
-					_('show user info')+' : @<input type="text" size="15" id="user_id" value="' + myname + '"><input type="image" src="images/go.png"></form>' +
+					_('show user info')+' : @<input type="text" size="15" id="user_id" value="' + myname + '"><button type="submit" class="go"></button></form>' +
 					'<a id="logout" href="javascript:logout()"><b>'+_('Log out')+'</b></a><hr class="spacer">' +
 					'<div id="pref"><a href="javascript:togglePreps()">▼<b>'+_('Preferences')+'</b></a>' +
 					'<form id="preps" onSubmit="try { setPreps(this); } catch(e) { alert(\'Cannot save preferences: \'+e) } return false;" style="display: none;">' +
 					_('language')+': <select name="user_lang">'+(['en'].concat(langList)).map(function(x){
 							return '<option value="'+x+'"'+(x==user_lang?' selected':'')+'>'+langNames[x]+'</option>';
 						})+'</select><br>' +
-					_('max #msgs in TL')+': <input name="limit" size="5" value="' + nr_limit + '"><br>' +
-					_('#msgs in TL on update (max=800)')+': <input name="maxc" size="3" value="' + max_count + '"><br>' +
-					_('#msgs in user on update (max=800)')+': <input name="maxu" size="3" value="' + max_count_u + '"><br>' +
-					_('update interval')+': <input name="interval" size="3" value="' + updateInterval + '"> sec<br>' +
-					'<input type="checkbox" name="since_check"' + (no_since_id?"":" checked") + '>'+_('since_id check')+'<br>' +
-					'<input type="checkbox" name="replies_in_tl"' + (replies_in_tl?" checked":"") + '>'+_('Show not-following replies in TL')+'<br>' +
-					'<input type="checkbox" name="reply_to_all"' + (reply_to_all?" checked":"") + '>'+_('Reply to all')+'<br>' +
-					'<input type="checkbox" name="display_as_rt"' + (display_as_rt?" checked":"") + '>'+_('Show retweets in "RT:" form')+'<br>' +
-					'<input type="checkbox" name="counter"' + (no_counter?"":" checked") + '>'+_('Post length counter')+'<br>' +
-					'<input type="checkbox" name="resize_fst"' + (no_resize_fst?"":" checked") + '>'+_('Auto-resize field')+'<br>' +
-					'<input type="checkbox" name="decr_enter"' + (decr_enter?" checked":"") + '>'+_('Post with ctrl/shift+enter')+'<br>' +
-					'<input type="checkbox" name="confirm_close"' + (confirm_close?" checked":"") + '>'+_('Confirm before closing tabs')+'<br>' +
-					'<input type="checkbox" name="geotag"' + (no_geotag?"":" checked") + '>'+_('Enable GeoTagging')+'<br>' +
-					'<input type="checkbox" name="post_via_agent"' + (post_via_agent?" checked":"") + '>'+_('Tweet via GAE server')+'<br>' +
-					'<input type="checkbox" name="show_header_img"' + (show_header_img?" checked":"") + '>'+_('Show header image')+'<br>' +
-					(navigator.userAgent.indexOf('WebKit') >= 0 ? '<input type="checkbox" name="dnd_image_upload"' + (dnd_image_upload?" checked":"") + '>'+_('Drag&drop image upload')+'<br>' : '') +
-					_('Footer')+': <input name="footer" size="20" value="' + footer + '"><br>' +
+					_('max #msgs in TL')+': <input type="text" name="limit" size="5" value="' + nr_limit + '"><br>' +
+					_('#msgs in TL on update (max=800)')+': <input type="text" name="maxc" size="3" value="' + max_count + '"><br>' +
+					_('#msgs in user on update (max=800)')+': <input type="text" name="maxu" size="3" value="' + max_count_u + '"><br>' +
+					_('update interval')+': <input type="text" name="interval" size="3" value="' + updateInterval + '"> sec<br>' +
+					'<label><input type="checkbox" name="since_check"' + (no_since_id?"":" checked") + '>'+_('since_id check')+'</label><br>' +
+					'<label><input type="checkbox" name="replies_in_tl"' + (replies_in_tl?" checked":"") + '>'+_('Show not-following replies in TL')+'</label><br>' +
+					'<label><input type="checkbox" name="reply_to_all"' + (reply_to_all?" checked":"") + '>'+_('Reply to all')+'</label><br>' +
+					'<label><input type="checkbox" name="display_as_rt"' + (display_as_rt?" checked":"") + '>'+_('Show retweets in "RT:" form')+'</label><br>' +
+					'<label><input type="checkbox" name="counter"' + (no_counter?"":" checked") + '>'+_('Post length counter')+'</label><br>' +
+					'<label><input type="checkbox" name="resize_fst"' + (no_resize_fst?"":" checked") + '>'+_('Auto-resize field')+'</label><br>' +
+					'<label><input type="checkbox" name="decr_enter"' + (decr_enter?" checked":"") + '>'+_('Post with ctrl/shift+enter')+'</label><br>' +
+					'<label><input type="checkbox" name="confirm_close"' + (confirm_close?" checked":"") + '>'+_('Confirm before closing tabs')+'</label><br>' +
+					'<label><input type="checkbox" name="geotag"' + (no_geotag?"":" checked") + '>'+_('Enable GeoTagging')+'</label><br>' +
+					'<label><input type="checkbox" name="post_via_agent"' + (post_via_agent?" checked":"") + '>'+_('Tweet via GAE server')+'</label><br>' +
+					'<label><input type="checkbox" name="show_header_img"' + (show_header_img?" checked":"") + '>'+_('Show header image')+'</label><br>' +
+					(navigator.userAgent.indexOf('WebKit') >= 0 ? '<label><input type="checkbox" name="dnd_image_upload"' + (dnd_image_upload?" checked":"") + '>'+_('Drag&drop image upload')+'</label><br>' : '') +
+					_('Footer')+': <input type="text" name="footer" size="20" value="' + footer + '"><br>' +
 					_('Plugins')+':<br><textarea cols="30" rows="4" name="list">' + pluginstr + '</textarea><br>' +
 					_('user stylesheet')+':<br><textarea cols="30" rows="4" name="user_style">' + user_style + '</textarea><br>' +
-					'<input type="submit" value="'+_('Save')+'">&nbsp;<button onclick="uploadSettings(); return false">'+_('Upload')+'</button><button onclick="downloadSettings(); return false">'+_('Download')+'</button></form></div><hr class="spacer">';
+					'<button type="submit">'+_('Save')+'</button>&nbsp;<button onclick="uploadSettings(); return false">'+_('Upload')+'</button><button onclick="downloadSettings(); return false">'+_('Download')+'</button></form></div><hr class="spacer">';
 	callPlugins("miscTab", $("tw2h"));
 	xds.load_for_tab(twitterAPI + 'application/rate_limit_status.json' +
 				'?suppress_response_codes=true&resources='+api_resources.join(','), twRateLimit);
@@ -1849,7 +1847,7 @@ function checkMedia() {
 // 画像アップロードボックスの表示
 function showMediaOption() {
 	if (!$('media'))
-		$("option").innerHTML += '<form id="imgup">'+_('Images')+': <div id="media_div"><input id="media" type="file" name="media[]" multiple onchange="checkMedia()" onclick="var m=$(\'media\').ondrop; if(m) m()"</div><img id="imgclr" src="images/clr.png" onclick="$(\'option\').removeChild($(\'imgup\'));setFstHeight(null,true)"></td></tr></table>';
+		$("option").innerHTML += '<form id="imgup">'+_('Images')+': <div id="media_div"><input id="media" type="file" name="media[]" multiple onchange="checkMedia()" onclick="var m=$(\'media\').ondrop; if(m) m()"</div><div id="imgclr" class="clr"  onclick="$(\'option\').removeChild($(\'imgup\'));setFstHeight(null,true)">';
 	setFstHeight(null, true);
 }
 // 初期化


### PR DESCRIPTION
ユーザCSSを書いていて気になった点を修正してみました。量が多くて申し訳ないのですが…。

* アイコン画像など一部要素をdivやspanで囲い、background-imageとして描画するように
* type属性のないinput要素にtypeを設定
* checkboxをlabelで囲い、クリックの当たり判定を拡張
* ボタンなど操作可能な要素にオンマウスで指カーソルへ変わるように