### PR TITLE
ioc_flags: Add KHL

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -365,7 +365,9 @@ registerPlugin({
 			'WRESTLING': 'Wrestling',
 			'レスリング': 'Wrestling',
 			'とと姉ちゃん': 'NHKMorningDrama',
-			'高校野球': 'JapanHighSchoolBaseballEmoji'
+			'高校野球': 'JapanHighSchoolBaseballEmoji',
+			'KHL': 'KHL_Season_Start',
+			'КХЛ': 'KHL_Season_Start'
 		};
 
 		// status


### PR DESCRIPTION
e.g. https://twitter.com/khl/statuses/767760371763544064

ロシアのホッケーリーグの絵文字対応です。

`#КХЛ` に絵文字を表示するためには `twicli.js` のロシア語ハッシュタグ対応が別途必要ですが...