### PR TITLE
plugins/embedsrc.js: Support SlideShare URL contain slash

### DIFF
--- a/plugins/embedsrc.js
+++ b/plugins/embedsrc.js
@@ -2,7 +2,7 @@
 	var res = [
 		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?(slideshow\/embed_code\/(?:key\/)?[-_0-9a-zA-Z.]+)/,
 			replace: "$1$2", type: "iframe"},
-		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?([-_0-9a-zA-Z.]+\/[-_0-9a-zA-Z.]+)/,
+		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?([-_0-9a-zA-Z.]+\/[-_0-9a-zA-Z.\/]+)/,
 			replace: "http://www.slideshare.net/api/oembed/2?url=$1$2&format=jsonp", type: "slideshare"},
 		{search: /^(https?:\/\/[\w\-]+\.tumblr\.com\/)post\/(\d+)(?:\/.*)/,
 			replace: "$1api/read/json?id=$2", type: "tumblr"},


### PR DESCRIPTION
SlideShare の URL の末尾に `/` を含んでいても埋め込み表示できるようにしました。

例: 
-   https://twitter.com/kdmsnr/statuses/968136694707896321
    -   `https://www.slideshare.net/KyokoOmi/ss-78046479/`