### PR TITLE
Enable thumbnail of Instagram with query string

### DIFF
--- a/plugins/thumbnail.js
+++ b/plugins/thumbnail.js
@@ -101,7 +101,7 @@ registerPlugin(thumbnail_plugin = {
 			else
 				addThumbnail(elem, 'http://tn-skr' + host + '.smilevideo.jp/smile?i=' + id, url);
 		}
-		else if (url.match(/^(https?:\/\/(?:www\.)?(?:instagr\.am|instagram\.com)\/p\/[\w\-]+)\/?$/)) {
+		else if (url.match(/^(https?:\/\/(?:www\.)?(?:instagr\.am|instagram\.com)\/p\/[\w\-]+)\/?(?:\??|$)/)) {
 			addThumbnail(elem, RegExp.$1+'/media/?size=t', url);
 		}
 		else if (url.match(/^(http:\/\/picplz.com\/\w+)/)) {


### PR DESCRIPTION
Instagram の URL に `?utm_source=twitter` 等が付いていてもサムネイルを表示できるようにしました。

-   https://www.instagram.com/p/BiN2m6Bj-F2/?utm_source=twitter