### PR TITLE
Avoid mixed content for some images

### DIFF
--- a/plugins/thumbnail.js
+++ b/plugins/thumbnail.js
@@ -112,7 +112,7 @@ registerPlugin(thumbnail_plugin = {
 							RegExp.$1 +"/org.bin?size=120", url);
 		}
 		else if (url.match(/^(https?:\/\/www\.slideshare\.net\/)(?!(?:mobile\/)?slideshow)(?:mobile\/)?([-_0-9a-zA-Z]+\/[-_0-9a-zA-Z]+)/)) {
-			xds.load("http://www.slideshare.net/api/oembed/2?url=" + RegExp.$1 + RegExp.$2 + "&format=jsonp",
+			xds.load("//www.slideshare.net/api/oembed/2?url=" + RegExp.$1 + RegExp.$2 + "&format=jsonp",
 					function(x) {
 						addThumbnail(elem, (x.thumbnail.substr(0,2) == '//' ? 'http:' : '' )+ x.thumbnail, url);
 					});
@@ -124,27 +124,27 @@ registerPlugin(thumbnail_plugin = {
 			addThumbnail(elem, RegExp.$1+':thumbnail', url);
 		}
 		else if (url.match(/^https?:\/\/vimeo\.com\/(?:m\/)?(\d+)$/)) {
-			xds.load("http://vimeo.com/api/v2/video/" + RegExp.$1 + ".json",
+			xds.load("//vimeo.com/api/v2/video/" + RegExp.$1 + ".json",
 				function(x) {
 					addThumbnail(elem, x[0].thumbnail_medium, url, x[0].title);
 				});
 		}
 		else if (url.match(/^(http:\/\/www\.pixiv\.net\/member_illust\.php\?(?:.*&)*illust_id=\d+.*)/)) {
-			xds.load("http://thumbnail-url.appspot.com/url?url=" + encodeURIComponent(RegExp.$1),
+			xds.load("//thumbnail-url.appspot.com/url?url=" + encodeURIComponent(RegExp.$1),
 				function(x) {
 					if (x && x.thumbnail)
 						addThumbnail(elem, x.thumbnail, url);
 				});
 		}
 		else if (url.match(/^(https?:\/\/(?:i\.)?gyazo\.com\/[0-9a-f]+)(?:\.png)?/)) {
-			xds.load("http://thumbnail-url.appspot.com/url?url=" + encodeURIComponent(RegExp.$1),
+			xds.load("//thumbnail-url.appspot.com/url?url=" + encodeURIComponent(RegExp.$1),
 				function(x) {
 					if (x && x.thumbnail)
 					addThumbnail(elem, x.thumbnail, url);
 			});
 		}
 		else if (url.match(/^(https?:\/\/(?:www\.)?amazon\.(?:co\.jp|jp|com)\/.*(?:d|dp|product|ASIN)[\/%].+)/)) {
-			xds.load("http://thumbnail-url.appspot.com/url?url=" + encodeURIComponent(RegExp.$1),
+			xds.load("//thumbnail-url.appspot.com/url?url=" + encodeURIComponent(RegExp.$1),
 				function(x) {
 					if (x && x.thumbnail)
 						addThumbnail(elem, x.thumbnail, x.link || url, x.title);

--- a/plugins/tweet_url_reply.js
+++ b/plugins/tweet_url_reply.js
@@ -64,7 +64,7 @@ function dispImageFromLink(url, e, type) {
 	  Array.prototype.map.call(media, function(x){
             return x.video_info ?
               Array.prototype.map.call(x.video_info.variants, function(y){return '[\'' + y.content_type + '\',\'' + y.url + '\']'}) :
-              '\'' + x.media_url + ':medium\''
+              '\'' + x.media_url_https + ':medium\''
           }).join(',') +
          '], this, \'' + media[0].type +'\'); return false;';
       }


### PR DESCRIPTION
展開した画像やサムネイルの取得先が `http` のため表示できなくなっているのを修正しました。