### PR TITLE
Avoid mixed content for some embed and translator

### DIFF
--- a/plugins/embedsrc.js
+++ b/plugins/embedsrc.js
@@ -3,7 +3,7 @@
 		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?(slideshow\/embed_code\/(?:key\/)?[-_0-9a-zA-Z.]+)/,
 			replace: "$1$2", type: "iframe"},
 		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?([-_0-9a-zA-Z.]+\/[-_0-9a-zA-Z.\/]+)/,
-			replace: "http://www.slideshare.net/api/oembed/2?url=$1$2&format=jsonp", type: "slideshare"},
+			replace: "//www.slideshare.net/api/oembed/2?url=$1$2&format=jsonp", type: "slideshare"},
 		{search: /^(https?:\/\/[\w\-]+\.tumblr\.com\/)post\/(\d+)(?:\/.*)/,
 			replace: "$1api/read/json?id=$2", type: "tumblr"},
 		{search: /^https?:\/\/(?:\w+\.)?theta360\.com\/(?:[sm]\/\w+|spheres\/samples\/[a-z0-9-]+)/,
@@ -11,12 +11,12 @@
 		{search: /^https?:\/\/(?:\w+\.)?pinterest\.com\/pin\/\d+/,
 			replace: "$&/", type: "pin"},
 		{search: /^https?:\/\/(?:(?:www\.|m\.|)youtube\.com\/watch\?.*v=|youtu\.be\/)([\w\-]+).*$/,
-			replace: "http://www.youtube.com/embed/$1", type: "iframe"},
+			replace: "//www.youtube.com/embed/$1", type: "iframe"},
 		{search: /^(https?:\/\/(?:i\.)?gyazo\.com\/[0-9a-f]+)(?:\.png)?$/,
 			replace: "$1.png", type: "iframe"},
 		{search: /^https?:\/\/gist\.github\.com\/([A-Za-z0-9-]+\/)?([A-Za-z0-9-]+)(?:\.txt)?$/, replace: "https://gist.github.com/$1$2.js", type: "script"},
 		{search: /^https?:\/\/raw\.github\.com\/gist\/(\d+)(?:.*)$/, replace: "https://gist.github.com/$1.js", type: "script"},
-		{search: /https?:\/\/(?:nico\.ms|www\.nicovideo\.jp\/watch)\/((?!lv)(?!nw)(?!im)[a-z]{2}\d+)/, replace: "http://ext.nicovideo.jp/thumb_watch/$1", type: "script"},
+		{search: /https?:\/\/(?:nico\.ms|www\.nicovideo\.jp\/watch)\/((?!lv)(?!nw)(?!im)[a-z]{2}\d+)/, replace: "//ext.nicovideo.jp/thumb_watch/$1", type: "script"},
 		{search: /^https?:\/\/vine\.co\/v\/(\w+)$/, replace: "https://vine.co/v/$1/embed/simple", type: "iframe"},
 		{search: /^https?:\/\/vimeo\.com\/(?:m\/)?(\d+)$/, replace: "https://player.vimeo.com/video/$1", type: "iframe"}
 	];
@@ -119,7 +119,7 @@ function dispEmbedSrc(url, link, type) {
 			break;
 		case 'slideshare':
 			xds.load(url, function(x) {
-				dispEmbedSrc("http:\/\/www\.slideshare\.net\/slideshow\/embed_code\/"
+				dispEmbedSrc("\/\/www\.slideshare\.net\/slideshow\/embed_code\/"
 					+ x.slideshow_id, link, 'iframe');
 			});
 			break;

--- a/plugins/thumbnail.js
+++ b/plugins/thumbnail.js
@@ -105,7 +105,7 @@ registerPlugin(thumbnail_plugin = {
 		else if (url.match(/^(https?:\/\/www\.slideshare\.net\/)(?!(?:mobile\/)?slideshow)(?:mobile\/)?([-_0-9a-zA-Z]+\/[-_0-9a-zA-Z]+)/)) {
 			xds.load("//www.slideshare.net/api/oembed/2?url=" + RegExp.$1 + RegExp.$2 + "&format=jsonp",
 					function(x) {
-						addThumbnail(elem, (x.thumbnail.substr(0,2) == '//' ? 'http:' : '' )+ x.thumbnail, url);
+						addThumbnail(elem, x.thumbnail, url);
 					});
 		}
 		else if (url.match(/^http:\/\/p\.twipple\.jp\/(\w+)/)) {

--- a/plugins/thumbnail.js
+++ b/plugins/thumbnail.js
@@ -111,7 +111,7 @@ registerPlugin(thumbnail_plugin = {
 		else if (url.match(/^http:\/\/p\.twipple\.jp\/(\w+)/)) {
 			addThumbnail(elem, 'http://p.twipple.jp/show/thumb/' + RegExp.$1, url);
 		}
-		else if (url.match(/^(http:\/\/moby\.to\/\w+)/)) {
+		else if (url.match(/^https?:(\/\/moby\.to\/\w+)/)) {
 			addThumbnail(elem, RegExp.$1+':thumbnail', url);
 		}
 		else if (url.match(/^https?:\/\/vimeo\.com\/(?:m\/)?(\d+)$/)) {

--- a/plugins/translate.js
+++ b/plugins/translate.js
@@ -27,7 +27,7 @@ registerPlugin({
 
 function translateStatus(id) {
 	window.translateTarget = $(id);
-	xds.load_for_tab("http://api.microsofttranslator.com/V2/Ajax.svc/Translate?"+
+	xds.load_for_tab("//api.microsofttranslator.com/V2/Ajax.svc/Translate?"+
 				"&appId=73B027BB51D74FB461C097BCCF841DB5678FDBB3" +
 				"&text=" + encodeURIComponent(text($(id).tw)) +
 				"&to="+translateLang, translateResult, 'oncomplete');


### PR DESCRIPTION
YouTube, ニコニコ動画、SlideShare の埋め込み表示と翻訳が https でも動作するようにしました。

また、SlideShare と Mobypicture のサムネイル表示の warning を抑止しました。