### PR TITLE
Replace native emoji with Twemoji (SVG)

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -717,7 +717,7 @@ registerPlugin({
 			}
 		});
 		Array.prototype.forEach.call(el.querySelectorAll('.uname, .status'), function(unparse) {
-			twemoji.parse(unparse);
+			twemoji.parse(unparse, { folder: 'svg', ext: '.svg' });
 		});
 
 		function getFlagImageHTML(iconName) {

--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -712,10 +712,12 @@ registerPlugin({
 				elHashtag.innerHTML += countryFlags[index].slice(2).map(function(s) {
 					return twemoji.convert.fromCodePoint(s);
 				}).join('');
-				twemoji.parse(elHashtag);
 			} else if (organization[index]) {
 				elHashtag.innerHTML += getFlagImageHTML(organization[index]);
 			}
+		});
+		Array.prototype.forEach.call(el.querySelectorAll('.uname, .status'), function(unparse) {
+			twemoji.parse(unparse);
 		});
 
 		function getFlagImageHTML(iconName) {


### PR DESCRIPTION
ハッシュタグ以外の絵文字も Twemoji (SVG) を使うようにしました。