### PR TITLE
plugins/ioc_flags.js: EnthronementCeremony_Emoji_GIF

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -779,6 +779,12 @@ registerPlugin({
 			'イヌの日': 'DogDay2019_Emoji_GIF',
 			'わんわんわんの日': 'DogDay2019_Emoji_GIF',
 			'うちの犬': 'DogDay2019_Emoji_GIF',
+			// https://twitter.com/TwitterJP/status/1193353369672241152
+			'即位の礼': 'EnthronementCeremony_Emoji_GIF',
+			'祝賀御列の儀': 'EnthronementCeremony_Emoji_GIF',
+			'即位礼正殿の儀': 'EnthronementCeremony_Emoji_GIF',
+			'JAPANENTHRONEMENT': 'EnthronementCeremony_Emoji_GIF',
+			'JPNENTHRONEMENT': 'EnthronementCeremony_Emoji_GIF',
 			// ---- その他 ----
 			'MYTWITTERANNIVERSARY': 'MyTwitterAnniversary',
 			'LOVETWITTER': 'LoveTwitter',


### PR DESCRIPTION
`#祝賀御列の儀` などの絵文字を追加しました。

-   [Twitter JapanさんはTwitterを使っています: 「昨晩は祝賀ムードに包まれるツイートがめだちました。 本日も「#祝賀御列の儀」 が午後3時00分からが行われます。ツイート時には以下のハッシュタグもあわせてご利用ください。国鳥の「キジ」が表示されます🇯🇵 #即位の礼 #祝賀御列の儀 #即位礼正殿の儀 #JapanEnthronement #JPNEnthronement https://t.co/y1ijCni27K」 / Twitter](https://twitter.com/TwitterJP/status/1193353369672241152)