### PR TITLE
Supress warning mixed content when loading flicker

### DIFF
--- a/plugins/thumbnail.js
+++ b/plugins/thumbnail.js
@@ -68,7 +68,7 @@ registerPlugin(thumbnail_plugin = {
 					function(x) {
 						var p = x.photo;
 						if (!p) return;
-						addThumbnail(elem, 'http://farm'+p.farm+'.static.flickr.com/'+p.server+'/'+
+						addThumbnail(elem, '//farm'+p.farm+'.static.flickr.com/'+p.server+'/'+
 									p.id+'_'+p.secret+'_s.jpg', _url);
 					},
 					null, 1, 'jsoncallback');

--- a/plugins/thumbnail.js
+++ b/plugins/thumbnail.js
@@ -68,7 +68,7 @@ registerPlugin(thumbnail_plugin = {
 					function(x) {
 						var p = x.photo;
 						if (!p) return;
-						addThumbnail(elem, '//farm'+p.farm+'.static.flickr.com/'+p.server+'/'+
+						addThumbnail(elem, '//farm'+(p.farm || 1)+'.static.flickr.com/'+p.server+'/'+
 									p.id+'_'+p.secret+'_s.jpg', _url);
 					},
 					null, 1, 'jsoncallback');


### PR DESCRIPTION
Flicker のサムネイル読み込み時に console.warn が出ないようにしました。