### PR TITLE
Emoji playstation ps5 and world refugees 2020

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -991,6 +991,11 @@ function tweReplaceEmoji(el) {
 		'PLAYSTATION5': 'PlayStationPS5_2020',
 		'PS5': 'PlayStationPS5_2020',
 		'PS5REVEAL': 'PlayStationPS5_2020_add',
+		// ---- 世界難民の日 ----
+		'世界難民の日': 'WorldRefugees2020',
+		'WORLDREFUGEEDAY': 'WorldRefugees2020',
+		'REFUGEEDAY': 'WorldRefugees2020',
+		'WITHREFUGEES': 'WorldRefugees2020',
 		// ---- その他 ----
 		'MYTWITTERANNIVERSARY': 'MyTwitterAnniversary',
 		'LOVETWITTER': 'LoveTwitter',

--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -987,6 +987,10 @@ function tweReplaceEmoji(el) {
 		'海外移住ストーリー': 'MyImmigrantStory_2020',
 		'国外移住ストーリー': 'MyImmigrantStory_2020',
 		'MYIMMIGRANTSTORY': 'MyImmigrantStory_2020',
+		// ---- PlayStationPS5 ----
+		'PLAYSTATION5': 'PlayStationPS5_2020',
+		'PS5': 'PlayStationPS5_2020',
+		'PS5REVEAL': 'PlayStationPS5_2020_add',
 		// ---- その他 ----
 		'MYTWITTERANNIVERSARY': 'MyTwitterAnniversary',
 		'LOVETWITTER': 'LoveTwitter',


### PR DESCRIPTION
`#世界難民の日` `#PLAYSTATION5` などの絵文字を追加しました。

![WorldRefugees2020.png (72×72)](https://abs.twimg.com/hashflags/WorldRefugees2020/WorldRefugees2020.png) ![PlayStationPS5_2020.png (72×72)](https://abs.twimg.com/hashflags/PlayStationPS5_2020/PlayStationPS5_2020.png)