### PR TITLE
Get hashtags mentions of tweet from entities

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -1017,10 +1017,7 @@ function tweReplaceEmoji(el) {
 
 	// status
 	Array.prototype.forEach.call(el.querySelectorAll('.status > .hashtag, .udesc > .hashtag'), function(elHashtag) {
-		var hashtag = elHashtag.innerHTML.match(hashtag_pattern);
-		if (!hashtag || hashtag.length < 2) return;
-
-		var index = hashtag[2].toUpperCase();
+		var index = elHashtag.innerHTML.replace(/^[#＃]/, '').toUpperCase();
 		if (countryFlags[index]) {
 			elHashtag.innerHTML += countryFlags[index].slice(2).map(function(s) {
 				return twemoji.convert.fromCodePoint(s);


### PR DESCRIPTION
下記のため、ツイート中のハッシュタグ、メンション、URL を正規表現によるマッチングに代え、`entities` から取得するようにしました。

-   正規表現のパターンで網羅できていない言語等のハッシュタグに対応
    -   ヒンディー語等
-   存在しないユーザーのリンクを抑止

但しユーザー情報 (プロフィール) は、 `entities` にハッシュタグ、メンションの情報が含まれないため、従来通り正規表現によるマッチングのままです...
