### PR TITLE
Emoji wwdc 2020

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -1004,6 +1004,7 @@ function tweReplaceEmoji(el) {
 		'BLACKLIVESMATTER': 'BlackHistoryMonth',
 		'MSBUILD': 'MSBuild_2020',
 		'APPLEEVENT': 'Wasabi_Emoji_2019',
+		'WWDC20': 'WWDC_2020_V1',
 		'夏はサボテンダー': 'DFF_OperaOmnia_2019_Emoji',
 		'午後の紅茶': 'KIRIN_GT_2_Japan_2019_Emoji_V2',
 		'午後ティー': 'KIRIN_GT_2_Japan_2019_Emoji_V2',

--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -1004,7 +1004,7 @@ function tweReplaceEmoji(el) {
 		'BLACKLIVESMATTER': 'BlackHistoryMonth',
 		'MSBUILD': 'MSBuild_2020',
 		'APPLEEVENT': 'Wasabi_Emoji_2019',
-		'WWDC20': 'WWDC_2020_V1',
+		'WWDC20': 'WWDC_2020_V2',
 		'夏はサボテンダー': 'DFF_OperaOmnia_2019_Emoji',
 		'午後の紅茶': 'KIRIN_GT_2_Japan_2019_Emoji_V2',
 		'午後ティー': 'KIRIN_GT_2_Japan_2019_Emoji_V2',


### PR DESCRIPTION
`#WWDC20` の絵文字を追加しました。

![WWDC_2020_V2.png (72×72)](https://abs.twimg.com/hashflags/WWDC_2020_V2/WWDC_2020_V2.png) ![WWDC_2020_V1.png (72×72)](https://abs.twimg.com/hashflags/WWDC_2020_V1/WWDC_2020_V1.png)

[WWDCのツイッターハッシュタグがカワイイ！ #WWDC20 | ギズモード・ジャパン](https://www.gizmodo.jp/2020/06/wwdc20-hashtag.html)