### PR TITLE
plugins/ioc_flags.js: WWDC_2020_V[1-11]

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -1004,7 +1004,7 @@ function tweReplaceEmoji(el) {
 		'BLACKLIVESMATTER': 'BlackHistoryMonth',
 		'MSBUILD': 'MSBuild_2020',
 		'APPLEEVENT': 'Wasabi_Emoji_2019',
-		'WWDC20': 'WWDC_2020_V[1-6]',
+		'WWDC20': 'WWDC_2020_V[1-11]',
 		'夏はサボテンダー': 'DFF_OperaOmnia_2019_Emoji',
 		'午後の紅茶': 'KIRIN_GT_2_Japan_2019_Emoji_V2',
 		'午後ティー': 'KIRIN_GT_2_Japan_2019_Emoji_V2',


### PR DESCRIPTION
`#WWDC20` の絵文字 11種類に対応しました。

![](https://abs.twimg.com/hashflags/WWDC_2020_V7/WWDC_2020_V7.png) ![](https://abs.twimg.com/hashflags/WWDC_2020_V8/WWDC_2020_V8.png) ![](https://abs.twimg.com/hashflags/WWDC_2020_V9/WWDC_2020_V9.png) ![](https://abs.twimg.com/hashflags/WWDC_2020_V10/WWDC_2020_V10.png) ![](https://abs.twimg.com/hashflags/WWDC_2020_V11/WWDC_2020_V11.png)
