### PR TITLE
plugins/geomap.js: Open link if there're no latitude and longitude

### DIFF
--- a/plugins/geomap.js
+++ b/plugins/geomap.js
@@ -34,6 +34,8 @@ registerPlugin({
 				display_map(rs.geo.coordinates, button);
 			} else if (rs.place && rs.place.bounding_box) {
 				display_placemap(rs.place, button);
+			} else {
+				return link(ev.currentTarget);
 			}
 			L.DomEvent.stop(ev);
 		});


### PR DESCRIPTION
位置情報付きツイートで経緯度情報が全く含まれていない場合に `geomap.js` プラグイン無効時と同様の動作にフォールバックするようにしました。

例: https://twitter.com/_wa_/statuses/1278669562100084742