### PR TITLE
plugins/ioc_flags.js: JP_FireworksDay_2020_BH

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -998,6 +998,9 @@ function tweReplaceEmoji(el) {
 		'WORLDREFUGEEDAY': 'WorldRefugees2020',
 		'REFUGEEDAY': 'WorldRefugees2020',
 		'WITHREFUGEES': 'WorldRefugees2020',
+		// ---- https://twitter.com/TwitterJP/statuses/1289367947610267649 ----
+		'花火': 'JP_FireworksDay_2020_BH',
+		'HANABI': 'JP_FireworksDay_2020_BH',
 		// ---- その他 ----
 		'MYTWITTERANNIVERSARY': 'MyTwitterAnniversary',
 		'LOVETWITTER': 'LoveTwitter',


### PR DESCRIPTION
`#花火` などの絵文字を追加しました。

![JP_FireworksDay_2020_BH.png (72×72)](https://abs.twimg.com/hashflags/JP_FireworksDay_2020_BH/JP_FireworksDay_2020_BH.png)