### PR TITLE
plugins/ioc_flags.js: AppleEvent_Nov_2020_BL_H2

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -1078,7 +1078,7 @@ function tweReplaceEmoji(el) {
 		'LOVETWITTER': 'LoveTwitter',
 		'METOO': 'MeToo_v3',
 		'MSBUILD': 'MSBuild_2020',
-		'APPLEEVENT': 'AppleEvent_Oct_2020',
+		'APPLEEVENT': 'AppleEvent_Nov_2020_BL_H2',
 		'WWDC20': 'WWDC_2020_V11',
 		'夏はサボテンダー': 'DFF_OperaOmnia_2019_Emoji',
 		'午後の紅茶': 'KIRIN_GT_2_Japan_2019_Emoji_V2',


### PR DESCRIPTION
`#applevent` の絵文字を更新しました。

![AppleEvent_Nov_2020_BL_H2.png (72×72)](https://abs.twimg.com/hashflags/AppleEvent_Nov_2020_BL_H2/AppleEvent_Nov_2020_BL_H2.png)