### PR TITLE
plugins/ioc_flags.js: AnimalCrossing_Nintendo_2020_NewArtwork_v2

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -905,12 +905,11 @@ function tweReplaceEmoji(el) {
 		'嵐と三ツ矢でカンパイ': 'AsahiMitsuyaJapan_2020',
 		'日本にはおいしいサイダーがある': 'AsahiMitsuyaJapan_2020',
 		// AnimalCrossing_Nintendo_2020_NewArtwork
-		'あつまれどうぶつの森': 'AnimalCrossing_Nintendo_2020_NewArtwork',
-		'どうぶつの森': 'AnimalCrossing_Nintendo_2020_NewArtwork',
-		'ACNH': 'AnimalCrossing_Nintendo_2020_NewArtwork',
-		'ANIMALCROSSING': 'AnimalCrossing_Nintendo_2020_NewArtwork',
-		'ANIMALCROSSINGNEWHORIZONS': 'AnimalCrossing_Nintendo_2020_NewArtwork',
-		'TOMNOOK': 'AnimalCrossing_Nintendo_2020_NewArtwork',
+		'あつまれどうぶつの森': 'AnimalCrossing_Nintendo_2020_NewArtwork_v2',
+		'どうぶつの森': 'AnimalCrossing_Nintendo_2020_NewArtwork_v2',
+		'ACNH': 'AnimalCrossing_Nintendo_2020_NewArtwork_v2',
+		'ANIMALCROSSING': 'AnimalCrossing_Nintendo_2020_NewArtwork_v2',
+		'ANIMALCROSSINGNEWHORIZONS': 'AnimalCrossing_Nintendo_2020_NewArtwork_v2',
 		// KIRINSoccerJapan_2020
 		'キリチャレの日': 'KIRINSoccerJapan_2020',
 		'届けてキリン': 'KIRINSoccerJapan_2020',


### PR DESCRIPTION
`#あつまれどうぶつの森` 関連の絵文字が 404 Not found になっていたのを補正しました。

![AnimalCrossing_Nintendo_2020_NewArtwork_v2.png (72×72)](https://abs.twimg.com/hashflags/AnimalCrossing_Nintendo_2020_NewArtwork_v2/AnimalCrossing_Nintendo_2020_NewArtwork_v2.png)

\# Twitter.com の絵文字表示は終了していますが…