### PR TITLE
plugins/embedsrc.js: Support www2.slideshare.net

### DIFF
--- a/plugins/embedsrc.js
+++ b/plugins/embedsrc.js
@@ -2,7 +2,7 @@
 	var res = [
 		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?(slideshow\/embed_code\/(?:key\/)?[-_0-9a-zA-Z.]+)/,
 			replace: "$1$2", type: "iframe"},
-		{search: /^(https?:\/\/www\.slideshare\.net\/)(?:mobile\/)?([-_0-9a-zA-Z.]+\/[-_0-9a-zA-Z./]+)/,
+		{search: /^(https?:\/\/www2?\.slideshare\.net\/)(?:mobile\/)?([-_0-9a-zA-Z.]+\/[-_0-9a-zA-Z./]+)/,
 			replace: "//www.slideshare.net/api/oembed/2?url=$1$2&format=jsonp", type: "slideshare"},
 		{search: /^(https?:\/\/[\w-]+\.tumblr\.com\/)post\/(\d+)(?:\/.*)/,
 			replace: "$1api/read/json?id=$2", type: "tumblr"},


### PR DESCRIPTION
`www2.slideshare.net` の URL で共有されたスライドの表示に対応しました。

`www3.slideshare.net` などは `www.slideshare.net` にリダイレクトされるのですが、 `www2` だけリダイレクトされないようです。