### PR TITLE
Avoid replacing line breaks with <br> in user description of quoted RT.

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -1195,7 +1195,7 @@ function makeHTML(tw, no_name, pid, userdesc, noctl) {
 			'onClick="fav(this,\'' + id + '\')"' + (pid ? ' id="fav-'+eid+'"' : '') + '><span></span></div>')+
 		 (!no_name || (!display_as_rt && rt) ?
 			//ユーザアイコン
-			'<img class="uicon" src="' + t.user.profile_image_url_https + '" title="' + (t.user.description ? t.user.description.replace(/"/g,'&quot;') :'') + '" onClick="switchUserTL(this.parentNode,'+rt_mode+');return false">' + (t.user.url ? '</a>' : '') +
+			'<img class="uicon" src="' + t.user.profile_image_url_https + '" title="' + (t.user.description ? t.user.description.replace(/"/g,'&quot;') :'').replace(/\r?\n|\r/g, noctl ? ' ' /* 引用 RT で <br> への置換抑止 */ : '$&') + '" onClick="switchUserTL(this.parentNode,'+rt_mode+');return false">' + (t.user.url ? '</a>' : '') +
 			//名前
 			'<a href="' + twitterURL + un + '" onClick="switchUserTL(this.parentNode,'+rt_mode+');return false" class="user"><span class="uid">@' + un + '</span>' +
 			 /*プロフィールの名前*/ '<span class="uname' + (t.user.name!=un ? '' : '_same') + '"><span class="uname_paren">(</span>'+insertPDF(t.user.name)+'<span class="uname_paren2">)</span></span></a>'


### PR DESCRIPTION
引用リツイートのユーザーアイコンの `title` 属性で、ユーザーの  description に含まれる改行が `<br>` というテキストに置換されるのを抑止しました。

できれば改行に置換したいところですが、それだと改修が大がかりになりそうなので、引用 RT の場合のみ空白に置換するようにしました。