### PR TITLE
plugins/embedsrc.js: Remove Gyazo because of same-origin policy

### DIFF
--- a/plugins/embedsrc.js
+++ b/plugins/embedsrc.js
@@ -12,8 +12,6 @@
 			replace: "$&/", type: "pin"},
 		{search: /^https?:\/\/(?:(?:www\.|m\.|)youtube\.com\/watch\?.*v=|youtu\.be\/)([\w-]+).*$/,
 			replace: "//www.youtube.com/embed/$1", type: "iframe"},
-		{search: /^(https?:\/\/(?:i\.)?gyazo\.com\/[0-9a-f]+)(?:\.png)?$/,
-			replace: "$1.png", type: "iframe"},
 		{search: /^https?:\/\/gist\.github\.com\/([A-Za-z0-9-]+\/)?([A-Za-z0-9-]+)(?:\.txt)?$/, replace: "https://gist.github.com/$1$2.js", type: "script"},
 		{search: /^https?:\/\/raw\.github\.com\/gist\/(\d+)(?:.*)$/, replace: "https://gist.github.com/$1.js", type: "script"},
 		{search: /https?:\/\/(?:nico\.ms|www\.nicovideo\.jp\/watch)\/((?!lv)(?!nw)(?!im)[a-z]{2}\d+)/, replace: "//ext.nicovideo.jp/thumb_watch/$1", type: "script"},


### PR DESCRIPTION
Gyazo を埋め込み表示すると `Refused to display 'https://i.gyazo.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.` となるため `plugins/embedsrc.js` から削除しました。
