### PR TITLE
Avoid refusal from Gyazo by using <img>

### DIFF
--- a/plugins/embedsrc.js
+++ b/plugins/embedsrc.js
@@ -13,7 +13,7 @@
 		{search: /^https?:\/\/(?:(?:www\.|m\.|)youtube\.com\/watch\?.*v=|youtu\.be\/)([\w-]+).*$/,
 			replace: "//www.youtube.com/embed/$1", type: "iframe"},
 		{search: /^(https?:\/\/(?:i\.)?gyazo\.com\/[0-9a-f]+)(?:\.png)?$/,
-			replace: "$1.png", type: "iframe"},
+			replace: "$1.png", type: "img"},
 		{search: /^https?:\/\/gist\.github\.com\/([A-Za-z0-9-]+\/)?([A-Za-z0-9-]+)(?:\.txt)?$/, replace: "https://gist.github.com/$1$2.js", type: "script"},
 		{search: /^https?:\/\/raw\.github\.com\/gist\/(\d+)(?:.*)$/, replace: "https://gist.github.com/$1.js", type: "script"},
 		{search: /https?:\/\/(?:nico\.ms|www\.nicovideo\.jp\/watch)\/((?!lv)(?!nw)(?!im)[a-z]{2}\d+)/, replace: "//ext.nicovideo.jp/thumb_watch/$1", type: "script"},
@@ -68,6 +68,7 @@ function dispEmbedSrc(url, link, type) {
 	var createIframe = function (content) {
 		var ifr = document.getElementById("embedsrc") || document.createElement("iframe");
 		ifr.id = "embedsrc";
+		ifr.sandbox = 'allow-same-origin';
 		ifr.style.border = "0";
 		ifr.style.width = "100%";
 		ifr.style.height = content.height || "426px";
@@ -131,9 +132,12 @@ function dispEmbedSrc(url, link, type) {
 				if (v) {
 					dispEmbedSrc(v, link, 'data');
 				} else if (p) {
-					dispEmbedSrc('<img src="' + p + '">', link, 'data');
+					dispEmbedSrc(p, link, 'img');
 				}
 			});
+			break;
+		case 'img':
+			dispEmbedSrc('<img src="' + url + '">', link, 'data');
 			break;
 	}
 }


### PR DESCRIPTION
`plugins/embedsrc.js` で Gyazo を埋め込み表示すると `Refused to display 'https://i.gyazo.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.` となるため、`iframe` に代えて `img` を使うようにしました。

関連: #206 
