### PR TITLE
plugins/ioc_flags.js: Beijing_Winter_Olympics_Biathlon_2022

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -452,6 +452,7 @@ var tweCategory = {
 	'Beijing_Winter_Olympics_#_2022': [
 		['AlpineSkiing', 'アルペンスキー'],
 		['Beijing2022', '北京2022'],
+		['Biathlon', 'バイアスロン'],
 		['Bobsleigh', 'ボブスレー'],
 		['Bronze', '銅メダル'],
 		['ClosingCeremony', '閉会式'],


### PR DESCRIPTION
`#バイアスロン` の絵文字が漏れていたのを直しました。

![Beijing_Winter_Olympics_Biathlon_2022.png (72×72)](https://abs.twimg.com/hashflags/Beijing_Winter_Olympics_Biathlon_2022/Beijing_Winter_Olympics_Biathlon_2022.png)