### PR TITLE
plugins/ioc_flags.js: CatDay_white_2022

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -446,6 +446,20 @@ var tweHashtag = {
 	'КХЛ': 'KHL_Season_Start'
 };
 var tweCategory = {
+	'CatDay_white_2022': [
+		[
+			'Twitter猫の日アンバサダー',
+			'にゃんにゃんにゃんの日',
+			'ねこ',
+			'ねこの日',
+			'ネコ',
+			'ネコの日',
+			'猫',
+			'猫のいる生活',
+			'猫の日',
+			'猫好きさんと繋がりたい'
+		]
+	],
 	'Beijing_Winter_#_2022': [
 		['Olympics', 'OlympicGames', 'オリンピック']
 	],


### PR DESCRIPTION
遅くなりましたが `#猫の日` などの絵文字を追加しました。

-   [2022年2月22日は特別な #猫の日](https://blog.twitter.com/ja_jp/topics/events/2022/2022-special-cat-day)

![CatDay_white_2022.png (72×72)](https://abs.twimg.com/hashflags/CatDay_white_2022/CatDay_white_2022.png)