### PR TITLE
plugins/ioc_flags.js: Japan_Upper_House_Election_Voted_Jun_2022

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -736,6 +736,7 @@ var tweCategory = {
 	],
 	'2020_TokyoGubernatorialElection': [['東京都知事選挙', '東京都知事選', '都知事選', '選挙に行こう']],
 	'Japan_Upper_House_Election_Jun_2022': [['私たちの選挙', '私たちの一票']],
+	'Japan_Upper_House_Election_Voted_Jun_2022': [['Voted', '投票しました']],
 	'WorldEmojiDay_2019': [
 		// [7月17日は #世界絵文字デー](https://blog.twitter.com/ja_jp/topics/events/2019/World-Emoji-Day-2019.html)
 		['WORLDEMOJIDAY', '世界絵文字デー', '鳥取', '鳥取県', '絵文字で鳥取県', 'おしどり', '絵文字', 'EMOJI']


### PR DESCRIPTION
`#投票しました` などの絵文字を追加しました。

-   [参院選 報道機関やNPOと連携し #私たちの選挙 を盛り上げる](https://blog.twitter.com/ja_jp/topics/events/2022/upperhouse-election)

![Japan_Upper_House_Election_Voted_Jun_2022.png (72×72)](https://abs.twimg.com/hashflags/Japan_Upper_House_Election_Voted_Jun_2022/Japan_Upper_House_Election_Voted_Jun_2022.png)