### PR TITLE
plugins/embedsrc.js: Prevent mixing of contents into overlay

### DIFF
--- a/plugins/embedsrc.js
+++ b/plugins/embedsrc.js
@@ -63,6 +63,7 @@
 }());
 
 function dispEmbedSrc(url, link, type) {
+	closeRep()
 	rep_top = Math.max(cumulativeOffset(link)[1] + 20, $("control").offsetHeight);
 	var win_h = window.innerHeight || document.documentElement.clientHeight;
 	var createIframe = function (content) {


### PR DESCRIPTION
引用リツイートや画像などをオーバーレイ表示中に embedsrc.js 対応コンテンツを表示すると元のオーバーレイの中に混在してしまうのを修正しました。
