### PR TITLE
Support twitterAPI2 in ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -96,6 +96,7 @@ overrides:
     twShow2: readonly
     twShowToNode: readonly
     twitterAPI: readonly
+    twitterAPI2: readonly
     twitterURL: readonly
     updateInterval: readonly
     user_picks: writable

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,10 +4,10 @@ jobs:
   ESLint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
     - run: yarn global add eslint
       name: Install ESLint
     - run: $(yarn global bin)/eslint .


### PR DESCRIPTION
ESLint に `twitterAPI2` を対応させました。

併せて GitHub Actions を更新しました。
[GitHub Actions: All Actions will begin running on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)