### PR TITLE
plugins/ioc_flags.js: Update CDN used by twemoji

### DIFF
--- a/plugins/ioc_flags.js
+++ b/plugins/ioc_flags.js
@@ -1,6 +1,6 @@
 var tweScript = document.createElement('script');
 tweScript.type = 'text/javascript';
-tweScript.src = '//twemoji.maxcdn.com/v/latest/twemoji.min.js';
+tweScript.src = '//unpkg.com/twemoji@latest/dist/twemoji.min.js';
 tweScript.crossorigin = 'anonymous';
 document.getElementsByTagName('body')[0].appendChild(tweScript);
 


### PR DESCRIPTION
twemoji で使用している CDN がシャットダウンしたため URL を更新しました。

Maxcdn has shut down, cdn not working anymore. · Issue #580 · twitter/twemoji https://github.com/twitter/twemoji/issues/580