### PR TITLE
Fix missing in_reply_to_status_id when retrying tweets

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -763,7 +763,6 @@ function press(e) {
 	do_post(true);
 	callPlugins("postQueued", text);
 	in_reply_to_user = null;
-	setReplyId(false);
 	return false;
 }
 // GeoTag


### PR DESCRIPTION
ツイートのリトライが発生した時に `in_reply_to_status_id` が欠落するのを修正してみました。

GAE 経由でツイート時にたまに `net::ERR_ABORTED 500` になり、そのときに `in_reply_to_status_id` が欠落するようでした。
