### PR TITLE
Shorten URL of image

### DIFF
--- a/twicli.js
+++ b/twicli.js
@@ -1192,8 +1192,10 @@ function makeHTML(tw, no_name, pid, userdesc, noctl) {
 					quoted = true;
 					return '<blockquote class="quoted">' + makeHTML(tw.quoted_status, false, pid, null, true) + '</blockquote>';
 				}
+				var status_url = twitterURL + tw.user.screen_name + '/status/' + id2 + '/'
 				return '<a class="link" target="_blank" href="' + e.replace(/"/g, '%22') + '" onclick="return link(this);">'
-					+ removeScheme(e).replace(/&/g, '&amp;') + '</a>';
+					+ (e.indexOf(status_url) === 0 ? (e.replace(status_url, '')) : removeScheme(e)).replace(/&/g, '&amp;')
+					+ '</a>';
 			}
 		}].forEach(function(a) {
 			var ttextWithLink = '';


### PR DESCRIPTION
ツイートに添付されている画像の URL の先頭を省略し、 `photo/1` のように短縮して表示をすっきりさせてみました。